### PR TITLE
fix(garmin): add activity-scoped badges to template context

### DIFF
--- a/chronicle/description_template.py
+++ b/chronicle/description_template.py
@@ -158,6 +158,9 @@ SAMPLE_TEMPLATE_CONTEXT: dict[str, Any] = {
     "garmin_badges": [
         "Garmin: Run Streak 400 (L1)",
     ],
+    "activity_badges": [
+        "February Weekend 10K",
+    ],
     "smashrun_badges": [
         "Smashrun: 1,000 Mile Month Club",
     ],
@@ -412,8 +415,12 @@ SAMPLE_TEMPLATE_CONTEXT: dict[str, Any] = {
         "badges": [
             "Garmin: Run Streak 400 (L1)",
         ],
+        "activity_badges": [
+            "February Weekend 10K",
+        ],
         "segment_notables": [],
         "last_activity": {
+            "activity_id": 21939412525,
             "activity_name": "Morning Run",
             "activity_type": "running",
             "start_local": "2026-02-15 06:42:00",
@@ -544,7 +551,15 @@ SAMPLE_TEMPLATE_CONTEXT: dict[str, Any] = {
     },
     "raw": {
         "activity": {"id": 1234567890},
-        "training": {},
+        "training": {
+            "garmin_badges_raw": [
+                {
+                    "badgeName": "February Weekend 10K",
+                    "badgeAssocType": "activityId",
+                    "badgeAssocDataId": "21939412525",
+                }
+            ]
+        },
         "intervals": {},
         "week": {},
         "month": {},
@@ -696,8 +711,10 @@ def _build_sample_fixtures() -> dict[str, dict[str, Any]]:
     strength_ctx["badges"] = []
     strength_ctx["strava_badges"] = []
     strength_ctx["garmin_badges"] = []
+    strength_ctx["activity_badges"] = []
     strength_ctx["smashrun_badges"] = []
     strength_ctx["smashrun"]["badges"] = []
+    strength_ctx["garmin"]["activity_badges"] = []
     strength_ctx["smashrun"]["latest_activity"] = {}
     strength_ctx["smashrun"]["stats"] = {}
 
@@ -2416,6 +2433,7 @@ def _type_name(value: Any) -> str:
 _GROUP_SOURCE_MAP: dict[str, tuple[str, str]] = {
     "achievements": ("Intervals.icu", "Achievement badges from Intervals activity payload."),
     "activity": ("Strava", "Latest activity metrics. Elevation can be overridden by Smashrun."),
+    "activity_badges": ("Garmin", "Garmin badges filtered to the current activity when linkage metadata is available."),
     "badges": ("Mixed", "Badge-style highlights from Strava, Garmin, and Smashrun."),
     "crono": ("crono-api", "Local nutrition/energy balance API values."),
     "garmin": ("Garmin", "Garmin-focused readiness, status, and run-dynamics metrics."),
@@ -2455,6 +2473,7 @@ _SOURCE_COST_TIER_MAP: dict[str, str] = {
 
 _GROUP_FRESHNESS_MAP: dict[str, str] = {
     "activity": "activity",
+    "activity_badges": "activity",
     "achievements": "activity",
     "badges": "activity",
     "intervals": "activity",
@@ -2508,6 +2527,14 @@ _FIELD_CATALOG_EXACT_MAP: dict[str, dict[str, Any]] = {
         "description": "Garmin badge highlights.",
         "tags": ["garmin", "badges", "activity"],
         "metric_key": "garmin_badges",
+    },
+    "activity_badges": {
+        "source": "Garmin",
+        "source_note": "Garmin badges filtered to current activity by badgeAssocType/activityId linkage.",
+        "label": "Activity Garmin Badges",
+        "description": "Garmin badge names earned by this activity only.",
+        "tags": ["garmin", "badges", "activity"],
+        "metric_key": "garmin_activity_badges",
     },
     "smashrun_badges": {
         "source": "Smashrun",
@@ -3157,6 +3184,14 @@ _FIELD_CATALOG_EXACT_MAP: dict[str, dict[str, Any]] = {
         "description": "Garmin earned badge lines.",
         "tags": ["garmin", "badges", "activity"],
         "metric_key": "garmin_badges_list",
+    },
+    "garmin.activity_badges": {
+        "source": "Garmin",
+        "source_note": "Garmin badge names linked to the current activity id.",
+        "label": "Garmin Activity Badge List",
+        "description": "Garmin badges earned by the latest processed activity.",
+        "tags": ["garmin", "badges", "activity"],
+        "metric_key": "garmin_activity_badges_list",
     },
     "garmin.segment_notables": {
         "source": "Garmin",

--- a/tests/test_description_template.py
+++ b/tests/test_description_template.py
@@ -290,6 +290,7 @@ class TestDescriptionTemplate(unittest.TestCase):
         self.assertIn("segment_notables", context)
         self.assertIn("strava_badges", context)
         self.assertIn("garmin_badges", context)
+        self.assertIn("activity_badges", context)
         self.assertIn("smashrun_badges", context)
         self.assertIn("strava_segment_notables", context)
         self.assertIn("garmin_segment_notables", context)
@@ -297,6 +298,7 @@ class TestDescriptionTemplate(unittest.TestCase):
         self.assertIn("badges", context["smashrun"])
         self.assertIn("last_activity", context["garmin"])
         self.assertIn("badges", context["garmin"])
+        self.assertIn("activity_badges", context["garmin"])
         self.assertIn("segment_notables", context["activity"])
         self.assertIn("index", context["misery"])
 

--- a/tests/test_garmin_metrics.py
+++ b/tests/test_garmin_metrics.py
@@ -188,8 +188,18 @@ class _DummyGarminClient:
 
     def get_earned_badges(self):
         return [
-            {"badgeName": "Run Streak 400", "badgeLevel": 1},
-            {"badgeName": "Weekend Warrior", "badgeLevel": 2},
+            {
+                "badgeName": "Run Streak 400",
+                "badgeLevel": 1,
+                "badgeAssocType": "activityId",
+                "badgeAssocDataId": "21922402831",
+            },
+            {
+                "badgeName": "Weekend Warrior",
+                "badgeLevel": 2,
+                "badgeAssocType": "activityId",
+                "badgeAssocDataId": "21900000000",
+            },
         ]
 
     def get_activities_by_date(self, _start_date, _end_date):
@@ -278,12 +288,17 @@ class TestVo2MaxExpandedMetrics(unittest.TestCase):
         self.assertEqual(metrics["fitness_age"], "34 yr")
         self.assertTrue(metrics["garmin_badges"])
         self.assertIn("Garmin: Run Streak 400 (L1)", metrics["garmin_badges"])
+        self.assertTrue(metrics["garmin_badges_raw"])
+        self.assertEqual(metrics["garmin_badges_raw"][0]["badgeName"], "Run Streak 400")
+        self.assertEqual(metrics["garmin_badges_raw"][0]["badgeAssocType"], "activityId")
+        self.assertEqual(metrics["garmin_badges_raw"][0]["badgeAssocDataId"], "21922402831")
         self.assertIn("Garmin 2nd: Hill Sprint (1:41)", metrics["garmin_segment_notables"])
         self.assertIn("Garmin PR: River Path (1:28)", metrics["garmin_segment_notables"])
 
         last_activity = metrics["garmin_last_activity"]
         self.assertIsInstance(last_activity, dict)
         self.assertEqual(last_activity["distance_miles"], "8.02 mi")
+        self.assertEqual(last_activity["activity_id"], 21922402831)
         self.assertEqual(last_activity["average_pace"], "7:19/mi")
         self.assertIn("Z1", last_activity["hr_zone_summary"])
         self.assertEqual(last_activity["total_sets"], 2)


### PR DESCRIPTION
## Summary
- preserve raw Garmin badge metadata as `garmin_badges_raw` in training metrics
- add `activity_id` to `garmin_last_activity` context
- add activity-scoped badge filtering by Garmin linkage fields (`badgeAssocType=activityId` + matching `badgeAssocDataId`)
- expose new template fields:
  - top-level `activity_badges`
  - nested `garmin.activity_badges`
- keep existing `garmin_badges` behavior unchanged for legacy templates
- update sample context/schema metadata and tests

## Validation
- `PYTHONPATH=. .venv/bin/python -m unittest tests.test_garmin_metrics -v`
- `PYTHONPATH=. .venv/bin/python -m unittest tests.test_activity_pipeline -v`
- `PYTHONPATH=. .venv/bin/python -m unittest tests.test_description_template -v`
- `PYTHONPATH=. .venv/bin/python -m unittest discover -s tests -p "test_*.py" -v` (192 passed)
- Live verification: activity `21939412525` resolves `activity_badges` to `['February Weekend 10K']`
- CI run `22270867375` passed (test + docker)

## Issues
- Refs #12
